### PR TITLE
Enable circuit disable signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Sell and buy items/fluids/energy on the universal black market using trading che
 * Add Transaction logs
 * Add stats Graph / income vs. expenses
 * Add support for factorio base game and space age DLC
+* Trading entities can connect to the circuit network to read contents and be enabled or disabled via signals
 * Support selling items with higher quality for higher price.
   * multiplyer are below:
     * normal -> 1x
@@ -53,4 +54,5 @@ Sell and buy items/fluids/energy on the universal black market using trading che
 * email: skghori03@gmail.com
 
 [![Flattr this git repo](http://api.flattr.com/button/flattr*badge*large.png)](https://flattr.com/submit/auto?user_id=djmango&url=https://github.com/djmango/BlackMarket2&title=BlackMarket2&language=&tags=github&category=software) 
+
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Sell and buy items/fluids/energy on the universal black market using trading che
 * Add stats Graph / income vs. expenses
 * Add support for factorio base game and space age DLC
 * Trading entities can connect to the circuit network to read contents and be enabled or disabled via signals
+* Trading chests function as logistic containers so robots can move items in or out
 * Support selling items with higher quality for higher price.
   * multiplyer are below:
     * normal -> 1x

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,9 @@
 ---------------------------------------------------------------------------------------------------
-Version: 2.2.15
-Date: 2025-07-08
+Version: 2.2.16
+Date: 2025-07-09
   Changes:
-    -  Trading entities now respond to a new circuit signal to disable trading
+    -  Trading chests are logistic containers so robots can insert or remove items
+    -  Trading entities respond to a circuit signal to disable trading
     -  Entities expose their inventories on the circuit network
 -------------------------------------------------------------------------------
 -------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,17 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.2.15
+Date: 2025-07-08
+  Changes:
+    -  Trading entities now respond to a new circuit signal to disable trading
+    -  Entities expose their inventories on the circuit network
+-------------------------------------------------------------------------------
+-------------------
+Version: 2.2.14
+Date: 2025-07-08
+  Changes:
+    -  Trading entities can connect to the circuit network and be disabled via signals
+-------------------------------------------------------------------------------
+-------------------
 Version: 2.2.12
 Date: 2024-11-09
   Changes:

--- a/control.lua
+++ b/control.lua
@@ -51,11 +51,12 @@ local function get_quality_multiplier(level) -- level is 1 indexed (1 = normal, 
 end
 
 local trader_signals =
-	{
-		auto_all = {type="virtual",name="signal-market-auto-all"},
-		auto_sell = {type="virtual",name="signal-market-auto-sell"},
-		auto_buy = {type="virtual",name="signal-market-auto-buy"},
-	}
+        {
+                auto_all = {type="virtual",name="signal-market-auto-all"},
+                auto_sell = {type="virtual",name="signal-market-auto-sell"},
+                auto_buy = {type="virtual",name="signal-market-auto-buy"},
+                disable = {type="virtual",name="signal-market-disable"},
+        }
 
 --------------------------------------------------------------------------------------
 function format_money( n )
@@ -1266,7 +1267,8 @@ end
 
 --------------------------------------------------------------------------------------
 local function init_trader( trader, level )
-	trader.auto = default_auto -- automatic trading
+       trader.auto = default_auto -- automatic trading
+       trader.disabled = false -- disabled via circuit signal
 	trader.daylight = false -- trades only during daylight (for selling accumulators)
 	trader.n_period=default_n_period
 	trader.period=periods[default_n_period]
@@ -1315,10 +1317,11 @@ end
 
 --------------------------------------------------------------------------------------
 local function copy_trader( trader1, trader2 )
-	trader2.auto = trader1.auto
-	trader2.daylight = trader1.daylight
-	trader2.n_period=trader1.n_period
-	trader2.period=trader1.period
+       trader2.auto = trader1.auto
+       trader2.daylight = trader1.daylight
+       trader2.n_period=trader1.n_period
+       trader2.period=trader1.period
+       trader2.disabled = trader1.disabled
 	
 	if (not trader1.sell_or_buy) and (not trader2.sell_or_buy) and trader1.type == trader2.type then
 		trader2.orders = {}
@@ -1419,9 +1422,11 @@ end
 
 --------------------------------------------------------------------------------------
 local function sell_trader(trader,force_mem,tax_rate)
-	if storage.prices_computed then return(nil) end
-	
-	if trader.entity == nil or not trader.entity.valid then return(nil) end
+        if storage.prices_computed then return(nil) end
+
+        if trader.entity == nil or not trader.entity.valid then return(nil) end
+
+       if trader.disabled then return(0) end
 	
 	if tax_rate == nil then tax_rate = storage.tax_rates[trader.period] end
 	if tax_enabled == false then tax_rate = 0 end
@@ -1519,9 +1524,11 @@ end
 
 --------------------------------------------------------------------------------------
 local function buy_trader(trader,force_mem,tax_rate)
-	if storage.prices_computed then return(nil) end
-	
-	if trader.entity == nil or not trader.entity.valid then return(nil) end
+        if storage.prices_computed then return(nil) end
+
+        if trader.entity == nil or not trader.entity.valid then return(nil) end
+
+       if trader.disabled then return(0) end
 	
 	if tax_rate == nil then	tax_rate = storage.tax_rates[trader.period] end
 	if tax_enabled == false then tax_rate = 0 end
@@ -1653,27 +1660,38 @@ local function listen_trader(trader)
 		network = ent.get_circuit_network(defines.wire_type.green)
 	end
 	
-	if network == nil then return(false) end
+       if network == nil then
+               trader.disabled = false
+               return(false)
+       end
+
+        local function listen_signal(signal)
+                local val = network.get_signal(signal)
+                -- debug_print( "auto=", val )
+                if val ~= 0 then
+                        local auto = (val ~= 1)
+                        if auto ~= trader.auto then changed = true end
+                        trader.auto = auto
+                end
+        end
+
+        listen_signal(trader_signals.auto_all)
 	
-	local function listen_signal(signal)
-		local val = network.get_signal(signal)
-		-- debug_print( "auto=", val )
-		if val ~= 0 then
-			local auto = (val ~= 1)
-			if auto ~= trader.auto then changed = true end
-			trader.auto = auto
-		end
-	end
-	
-	listen_signal(trader_signals.auto_all)
-	
-	if trader.sell_or_buy then
-		listen_signal(trader_signals.auto_sell)
-	else
-		listen_signal(trader_signals.auto_buy)
-	end
-	
-	if trader.editer and changed then update_menu_trader(trader.editer,nil,false) end
+       if trader.sell_or_buy then
+               listen_signal(trader_signals.auto_sell)
+       else
+               listen_signal(trader_signals.auto_buy)
+       end
+
+       local disable = network.get_signal(trader_signals.disable) ~= 0
+       if disable ~= trader.disabled then
+               trader.disabled = disable
+               changed = true
+       end
+
+       local force_mem = storage.force_mem[ent.force.name]
+
+       if trader.editer and changed then update_menu_trader(trader.editer,nil,false) end
 	
 	return(true)
 end
@@ -2361,7 +2379,7 @@ local function on_tick(event)
 					local trader = force_mem.traders_sell[i]
 					if storage.hour % trader.period == 0 then
 						trader.hour_period = storage.hour
-						if trader.auto and not force_mem.pause then
+                                               if trader.auto and not trader.disabled and not force_mem.pause then
 							local ent = trader.entity
 							-- if not(trader.daylight and trader.type == trader_type.energy and ent.surface.darkness > 0.5) then
 								local money1 = sell_trader(trader,force_mem)
@@ -2394,7 +2412,7 @@ local function on_tick(event)
 					local trader = force_mem.traders_buy[i]
 					if storage.hour % trader.period == 0 then
 						trader.hour_period = storage.hour
-						if trader.auto and not force_mem.pause then
+                                               if trader.auto and not trader.disabled and not force_mem.pause then
 							local money1 = buy_trader(trader,force_mem)
 							if money1 == nil then
 								table.remove(force_mem.traders_buy,i)
@@ -2421,7 +2439,7 @@ local function on_tick(event)
 				
 				for i=#force_mem.traders_sell,1,-1 do
 					local trader = force_mem.traders_sell[i]
-					if trader.auto and (not force_mem.pause) and storage.hour % trader.period == 0 then
+                                        if trader.auto and (not trader.disabled) and (not force_mem.pause) and storage.hour % trader.period == 0 then
 						compute_trader_data(trader)
 						trader.money_period = trader.money_tot - trader.money_tot_start_period
 						-- debug_print(trader.money_tot_start_period, " -> ", trader.money_tot, " = ", trader.money_period)
@@ -2431,7 +2449,7 @@ local function on_tick(event)
 				
 				for i=#force_mem.traders_buy,1,-1 do
 					local trader = force_mem.traders_buy[i]
-					if trader.auto and (not force_mem.pause) and storage.hour % trader.period == 0 then
+                                        if trader.auto and (not trader.disabled) and (not force_mem.pause) and storage.hour % trader.period == 0 then
 						compute_trader_data(trader)
 						trader.money_period = trader.money_tot - trader.money_tot_start_period
 						-- debug_print(trader.money_tot_start_period, " -> ", trader.money_tot, " = ", trader.money_period)

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "BlackMarket2",
-	"version": "2.2.12",
+    "version": "2.2.15",
 	"title": "Black Market 2",
 	"author": "djmango",
 	"description": "Sell and buy items/fluids/energy on the universal black market using trading chests/tanks/accumulators, choosing the frequency of exchanges and related fees. You can now sell your overproduction and buy things that you don't want to craft by yourself. You can also use these trading units as a paying shipment system.",

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "BlackMarket2",
-    "version": "2.2.15",
+    "version": "2.2.16",
 	"title": "Black Market 2",
 	"author": "djmango",
 	"description": "Sell and buy items/fluids/energy on the universal black market using trading chests/tanks/accumulators, choosing the frequency of exchanges and related fees. You can now sell your overproduction and buy things that you don't want to craft by yourself. You can also use these trading units as a paying shipment system.",

--- a/locale/cn/cn.cfg
+++ b/locale/cn/cn.cfg
@@ -202,6 +202,7 @@ trader-accu-sel-mk4=交易蓄电池 MK4 (卖出)
 signal-market-auto-all=自动交易:开启(>1)/off(=1)/ignore(=0)
 signal-market-auto-sel=自动卖出模式: 开启(>1)/off(=1)/ignore(=0)
 signal-market-auto-buy=自动买入模式: 开启(>1)/off(=1)/ignore(=0)
+signal-market-disable=信号>0时禁用交易
 
 [mod-setting-name]
 BM2-dynamic_prices=启用动态价格

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -203,6 +203,7 @@ trader-accu-sel-mk4=Trading accumulator MK4 (sell)
 signal-market-auto-all=Traders automatic mode: on(>1)/off(=1)/ignore(=0)
 signal-market-auto-sel=Traders automatic sell mode: on(>1)/off(=1)/ignore(=0)
 signal-market-auto-buy=Traders automatic buy mode: on(>1)/off(=1)/ignore(=0)
+signal-market-disable=Disable trading when signal > 0
 
 [mod-setting-name]
 BM2-dynamic_prices=Enable dynamic prices

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -230,8 +230,9 @@ local function add_chests(level)
 		enabled = false
 	end
 
-       -- use a logistic container so robots can interact with traders
-       local chest_sell = dupli_proto( "logistic-container", "logistic-chest-passive-provider", name_sell )
+       -- duplicate a basic chest and convert it into a logistic container so robots can interact
+       local chest_sell = dupli_proto( "container", proto, name_sell )
+       chest_sell.type = "logistic-container"
        chest_sell.inventory_size = inventory_size
        chest_sell.logistic_mode = "passive-provider"
        chest_sell.circuit_wire_connection_points = circuit_connector_definitions["chest"].points
@@ -277,7 +278,8 @@ local function add_chests(level)
 	table.insert(names_chests,name_buy)
 	table.insert(names_pastable,name_buy)
 	--------------------------------------------------------------------------------------
-       local chest_buy = dupli_proto( "logistic-container", "logistic-chest-requester", name_buy )
+       local chest_buy = dupli_proto( "container", proto, name_buy )
+       chest_buy.type = "logistic-container"
        chest_buy.inventory_size = inventory_size
        chest_buy.logistic_mode = "requester"
        chest_buy.logistic_slots_count = 12

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -590,7 +590,7 @@ add_accus(4)
 
 --------------------------------------------------------------------------------------
 for _, name in pairs(names_chests) do
-	data.raw["container"][name].additional_pastable_entities = names_pastable
+       data.raw["logistic-container"][name].additional_pastable_entities = names_pastable
 end
 
 for _, name in pairs(names_tanks) do

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -230,8 +230,10 @@ local function add_chests(level)
 		enabled = false
 	end
 
-        local chest_sell = dupli_proto( "container", proto, name_sell )
+       -- use a logistic container so robots can interact with traders
+       local chest_sell = dupli_proto( "logistic-container", "logistic-chest-passive-provider", name_sell )
        chest_sell.inventory_size = inventory_size
+       chest_sell.logistic_mode = "passive-provider"
        chest_sell.circuit_wire_connection_points = circuit_connector_definitions["chest"].points
        chest_sell.circuit_connector_sprites = circuit_connector_definitions["chest"].sprites
        chest_sell.circuit_wire_max_distance = default_circuit_wire_max_distance
@@ -275,8 +277,10 @@ local function add_chests(level)
 	table.insert(names_chests,name_buy)
 	table.insert(names_pastable,name_buy)
 	--------------------------------------------------------------------------------------
-        local chest_buy = dupli_proto( "container", proto, name_buy )
+       local chest_buy = dupli_proto( "logistic-container", "logistic-chest-requester", name_buy )
        chest_buy.inventory_size = inventory_size
+       chest_buy.logistic_mode = "requester"
+       chest_buy.logistic_slots_count = 12
        chest_buy.circuit_wire_connection_points = circuit_connector_definitions["chest"].points
        chest_buy.circuit_connector_sprites = circuit_connector_definitions["chest"].sprites
        chest_buy.circuit_wire_max_distance = default_circuit_wire_max_distance

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -230,8 +230,12 @@ local function add_chests(level)
 		enabled = false
 	end
 
-	local chest_sell = dupli_proto( "container", proto, name_sell )
-	chest_sell.inventory_size = inventory_size
+        local chest_sell = dupli_proto( "container", proto, name_sell )
+       chest_sell.inventory_size = inventory_size
+       chest_sell.circuit_wire_connection_points = circuit_connector_definitions["chest"].points
+       chest_sell.circuit_connector_sprites = circuit_connector_definitions["chest"].sprites
+       chest_sell.circuit_wire_max_distance = default_circuit_wire_max_distance
+       chest_sell.circuit_enable_disable = true
 	chest_sell.picture = 
 		{
 			filename = "__BlackMarket2__/graphics/trading-chest-sell.png",
@@ -271,8 +275,12 @@ local function add_chests(level)
 	table.insert(names_chests,name_buy)
 	table.insert(names_pastable,name_buy)
 	--------------------------------------------------------------------------------------
-	local chest_buy = dupli_proto( "container", proto, name_buy )
-	chest_buy.inventory_size = inventory_size
+        local chest_buy = dupli_proto( "container", proto, name_buy )
+       chest_buy.inventory_size = inventory_size
+       chest_buy.circuit_wire_connection_points = circuit_connector_definitions["chest"].points
+       chest_buy.circuit_connector_sprites = circuit_connector_definitions["chest"].sprites
+       chest_buy.circuit_wire_max_distance = default_circuit_wire_max_distance
+       chest_buy.circuit_enable_disable = true
 	chest_buy.picture = 
 		{
 			filename = "__BlackMarket2__/graphics/trading-chest-buy.png",
@@ -350,9 +358,13 @@ local function add_tanks(level)
 	if level == 3 then tank_max = 200000 end
 	if level == 4 then tank_max = 400000 end
 	--------------------------------------------------------------------------------------
-	local tank_sell = dupli_proto( "storage-tank", "storage-tank", name_sell )
-	tank_sell.pictures.picture.sheets[1].filename = "__BlackMarket2__/graphics/trading-tank-sell.png"
-	tank_sell.fluid_box.volume = tank_max
+        local tank_sell = dupli_proto( "storage-tank", "storage-tank", name_sell )
+        tank_sell.pictures.picture.sheets[1].filename = "__BlackMarket2__/graphics/trading-tank-sell.png"
+        tank_sell.fluid_box.volume = tank_max
+       tank_sell.circuit_wire_connection_points = circuit_connector_definitions["storage-tank"].points
+       tank_sell.circuit_connector_sprites = circuit_connector_definitions["storage-tank"].sprites
+       tank_sell.circuit_wire_max_distance = default_circuit_wire_max_distance
+       tank_sell.circuit_enable_disable = true
 
 	data:extend(
 		{
@@ -384,9 +396,13 @@ local function add_tanks(level)
 	)
 
 	--------------------------------------------------------------------------------------
-	local tank_buy = dupli_proto( "storage-tank", "storage-tank", name_buy )
-	tank_buy.pictures.picture.sheets[1].filename = "__BlackMarket2__/graphics/trading-tank-buy.png"
-	tank_buy.fluid_box.volume = tank_max
+        local tank_buy = dupli_proto( "storage-tank", "storage-tank", name_buy )
+        tank_buy.pictures.picture.sheets[1].filename = "__BlackMarket2__/graphics/trading-tank-buy.png"
+        tank_buy.fluid_box.volume = tank_max
+       tank_buy.circuit_wire_connection_points = circuit_connector_definitions["storage-tank"].points
+       tank_buy.circuit_connector_sprites = circuit_connector_definitions["storage-tank"].sprites
+       tank_buy.circuit_wire_max_distance = default_circuit_wire_max_distance
+       tank_buy.circuit_enable_disable = true
 
 	data:extend(
 		{
@@ -462,10 +478,14 @@ local function add_accus(level)
 	if level == 3 then flow_limit = 10 end
 	if level == 4 then flow_limit = 25 end
 	--------------------------------------------------------------------------------------
-	local accu_sell = dupli_proto( "accumulator", "accumulator", name_sell )
-	accu_sell.energy_source.buffer_capacity = accu_max .. "MJ"
-	accu_sell.energy_source.input_flow_limit = flow_limit .. "MW"
-	accu_sell.energy_source.output_flow_limit = "0MW"
+        local accu_sell = dupli_proto( "accumulator", "accumulator", name_sell )
+        accu_sell.energy_source.buffer_capacity = accu_max .. "MJ"
+        accu_sell.energy_source.input_flow_limit = flow_limit .. "MW"
+        accu_sell.energy_source.output_flow_limit = "0MW"
+        accu_sell.circuit_wire_connection_points = circuit_connector_definitions["accumulator"].points
+        accu_sell.circuit_connector_sprites = circuit_connector_definitions["accumulator"].sprites
+        accu_sell.circuit_wire_max_distance = default_circuit_wire_max_distance
+        accu_sell.circuit_enable_disable = true
 	accu_sell.chargable_graphics.picture.filename = "__BlackMarket2__/graphics/trading-accumulator-sell.png"
 	accu_sell.chargable_graphics.charge_animation.filename = "__BlackMarket2__/graphics/trading-accumulator-sell-charge.png"
 	accu_sell.chargable_graphics.discharge_animation.filename = "__BlackMarket2__/graphics/trading-accumulator-sell-discharge.png"
@@ -500,10 +520,14 @@ local function add_accus(level)
 	)
 
 	--------------------------------------------------------------------------------------
-	local accu_buy = dupli_proto( "accumulator", "accumulator", name_buy )
-	accu_buy.energy_source.buffer_capacity = accu_max .. "MJ"
-	accu_buy.energy_source.input_flow_limit = "0MW"
-	accu_buy.energy_source.output_flow_limit = flow_limit .. "MW"
+        local accu_buy = dupli_proto( "accumulator", "accumulator", name_buy )
+        accu_buy.energy_source.buffer_capacity = accu_max .. "MJ"
+        accu_buy.energy_source.input_flow_limit = "0MW"
+        accu_buy.energy_source.output_flow_limit = flow_limit .. "MW"
+        accu_buy.circuit_wire_connection_points = circuit_connector_definitions["accumulator"].points
+        accu_buy.circuit_connector_sprites = circuit_connector_definitions["accumulator"].sprites
+        accu_buy.circuit_wire_max_distance = default_circuit_wire_max_distance
+        accu_buy.circuit_enable_disable = true
 	accu_buy.chargable_graphics.picture.filename = "__BlackMarket2__/graphics/trading-accumulator-buy.png"
 	accu_buy.chargable_graphics.charge_animation.filename = "__BlackMarket2__/graphics/trading-accumulator-buy-charge.png"
 	accu_buy.chargable_graphics.discharge_animation.filename = "__BlackMarket2__/graphics/trading-accumulator-buy-discharge.png"

--- a/prototypes/signals.lua
+++ b/prototypes/signals.lua
@@ -23,14 +23,22 @@ data:extend(
 			subgroup = "virtual-signal-market",
 			order = "y[market]-ab"
 		},
-		{
-			type = "virtual-signal",
-			name = "signal-market-auto-buy",
-			icon = "__BlackMarket2__/graphics/signal-market-auto-buy.png",
-			icon_size = 32,
-			subgroup = "virtual-signal-market",
-			order = "y[market]-ac"
-		},
+                {
+                        type = "virtual-signal",
+                        name = "signal-market-auto-buy",
+                        icon = "__BlackMarket2__/graphics/signal-market-auto-buy.png",
+                        icon_size = 32,
+                        subgroup = "virtual-signal-market",
+                        order = "y[market]-ac"
+                },
+                {
+                        type = "virtual-signal",
+                        name = "signal-market-disable",
+                        icon = "__BlackMarket2__/graphics/signal-market-auto-all.png",
+                        icon_size = 32,
+                        subgroup = "virtual-signal-market",
+                        order = "y[market]-ad"
+                },
 
 
 	}


### PR DESCRIPTION
## Summary
- add new `signal-market-disable` virtual signal
- trading entities expose inventories and can be disabled with the new signal
- document circuit signal usage
- remove binary image for disable signal and reuse existing icon

## Testing
- `luajit -b control.lua /tmp/control.luac`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686cea685100832083c33198c3c56cf9